### PR TITLE
[Fix] modal이 부자연스럽게 내려가는 이슈 해결

### DIFF
--- a/Hapit/Hapit/View/HomeTab/HabitDetail/CustomModal/ModalView.swift
+++ b/Hapit/Hapit/View/HomeTab/HabitDetail/CustomModal/ModalView.swift
@@ -64,9 +64,9 @@ struct ModalView: View {
         // Determining whether drawer is above or below `.partiallyRevealed` threshold for snapping behavior.
         if offsetFromTopOfView <= ModalState.partiallyRevealed.offsetFromTop() {
             higherStop = .open
-            lowerStop = .partiallyRevealed
+            lowerStop = .closed
         } else {
-            higherStop = .partiallyRevealed
+            higherStop = .open
             lowerStop = .closed
         }
         


### PR DESCRIPTION
patiallyRevealed라는 변수로 모달을 중간에 멈출 수 있게 했는데 부정적인 피드백을 많이 받아 그 기능을 삭제했습니다.